### PR TITLE
* Move prerequisite declaration to CPANfile

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,0 +1,10 @@
+#!perl
+
+requires 'perl', '5.10.1';
+
+requires 'Mojolicious';
+requires 'Mojolicious::Plugin::Authentication';
+requires 'Mojolicious::Plugin::HttpBasicAuth';
+requires 'Minion';
+requires 'Rex';
+

--- a/dist.ini
+++ b/dist.ini
@@ -13,9 +13,4 @@ copyright_holder = Jan Gehring
 ; [Test::Perl::Critic]
 [PkgVersion]
 
-[Prereqs]
-Mojolicious = 0
-Mojolicious::Plugin::Authentication = 0
-Mojolicious::Plugin::HttpBasicAuth = 0
-Minion = 0
-Rex = 0
+[Prereqs::FromCPANfile]


### PR DESCRIPTION
Because it's the goto-tool for dependency
installation in today's Perl world.